### PR TITLE
Use latest linter release

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ runs:
 
     - id: install
       name: Install dependencies
-      run: npm install github:stamen/mapbox-gl-style-linter#v0.1.2 --global
+      run: npm install github:stamen/mapbox-gl-style-linter#v0.1.3 --global
       shell: bash
 
     - id: run-lint


### PR DESCRIPTION
Uses latest linter which lints with layer ids instead of layer index: https://github.com/stamen/mapbox-gl-style-linter/releases/tag/v0.1.3

